### PR TITLE
fix: add missing pins for kubic

### DIFF
--- a/vars/kubic.yml
+++ b/vars/kubic.yml
@@ -5,6 +5,8 @@ url: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/sta
 suites: /
 key_path: kubic.asc
 packages:
+  - conmon
+  - crun
   - fuse-overlayfs
   - podman
   - slirp4netns


### PR DESCRIPTION
Fixes #8 - Broken installation on Ubuntu 20.04.