### PR TITLE
Add gitlab runner as preset repo

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -69,3 +69,5 @@
       # override preset partially (binary key)
       - preset: gitlab
         key_path: gitlab.gpg
+      # Gitlab runner test
+      - preset: gitlab_runner

--- a/vars/gitlab_runner.yml
+++ b/vars/gitlab_runner.yml
@@ -1,0 +1,6 @@
+---
+name: gitlab_runner.packages.gitlab.com
+url: https://packages.gitlab.com/runner/gitlab-runner/{{ ansible_distribution|lower }}/
+key_path: gitlab.asc
+packages:
+  - gitlab-runner


### PR DESCRIPTION
Add gitlab runner as preset repo.

Since it has a different Url than the gitlab package, it has to be an individual entry as preset file.