### PR TITLE
Make APT pinning optional, but enabled by default

### DIFF
--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -72,3 +72,4 @@
     owner: root
     group: root
     mode: 0644
+  when: _config.pin | default(true) | bool


### PR DESCRIPTION
This change implements custom APT pinning, if necessary.